### PR TITLE
Allow display of posterior mean correlation coefficient along edges of graph

### DIFF
--- a/R/network_graph.R
+++ b/R/network_graph.R
@@ -45,7 +45,7 @@ apply_colors <- function(R, name = "RdBu") {
     }
   }
   dat <- data.frame(color = color_vector,
-                    label = round(r_vector, 3))
+                    label = r_vector)
   return(dat)
 }
 
@@ -63,6 +63,10 @@ apply_colors <- function(R, name = "RdBu") {
 #' @param style Style of visualization, "arc" (default) or "line"
 #' @param palette RColorBrewer palette to use. See `apply_colors()` for
 #' details. Default: "RdBu"
+#' @param label_edges Label edges of graph with posterior mean correlation.
+#' Default: FALSE
+#' @param digits Number of digits to use in rounding posterior mean correlation
+#' (only relevant if label_edges == TRUE). Default: 2
 #'
 #' @return A list with two elements
 #'
@@ -72,7 +76,10 @@ apply_colors <- function(R, name = "RdBu") {
 #'
 #' @export
 plot_posterior_correlation <- function(output_model, labels = NULL,
-                                       style = "arc", palette = "RdBu")
+                                       style = "arc",
+                                       palette = "RdBu",
+                                       label_edges = FALSE,
+                                       digits = 2)
 {
   Omega <- get_Omega(output_model)
   model_df <- as.data.frame(output_model)
@@ -116,29 +123,38 @@ plot_posterior_correlation <- function(output_model, labels = NULL,
 
   df <- apply_colors(R)
 
-  igraph::E(graph)$Correlation <- df$color #apply_colors(R, palette)
-  igraph::E(graph)$label <- df$label
+  igraph::E(graph)$Correlation <- df$color
+  igraph::E(graph)$label <- round(df$label, digits)
   igraph::E(graph)$P_value <- weight_vector
 
+  p <- ggraph::ggraph(graph, layout = "linear", circular = TRUE)
   if (style == "arc") {
-    p <- ggraph::ggraph(graph, layout = "linear", circular = TRUE) +
-      ggraph::geom_edge_arc(ggplot2::aes(edge_width = P_value,
-                                         edge_color = Correlation,
-                                         label = label),
-                            angle_calc = "along",
-                            check_overlap = TRUE) +
-      ggraph::geom_node_point(size = 5) +
+    if (label_edges) {
+      p <- p + ggraph::geom_edge_arc(ggplot2::aes(edge_width = P_value,
+                                                  edge_color = Correlation,
+                                                  label = label),
+                                     angle_calc = "along",
+                                     check_overlap = TRUE)
+    } else {
+      p <- p + ggraph::geom_edge_arc(ggplot2::aes(edge_width = P_value,
+                                                  edge_color = Correlation))
+    }
+    p <- p + ggraph::geom_node_point(size = 5) +
       ggraph::geom_node_label(ggplot2::aes(label = name),
                               size = 5) +
       ggraph::theme_graph()
   } else if (style == "line") {
-    p <- ggraph::ggraph(graph, layout = "linear", circular = TRUE) +
-      ggraph::geom_edge_link(ggplot2::aes(edge_width = P_value,
-                                          edge_color = Correlation,
-                                          label = label),
-                             angle_calc = "along",
-                             check_overlap = TRUE) +
-      ggraph::geom_node_point(size = 5) +
+    if (label_edges) {
+      p <- p + ggraph::geom_edge_link(ggplot2::aes(edge_width = P_value,
+                                                   edge_color = Correlation,
+                                                   label = label),
+                                      angle_calc = "along",
+                                      check_overlap = TRUE)
+    } else {
+      p <- p + ggraph::geom_edge_link(ggplot2::aes(edge_width = P_value,
+                                                   edge_color = Correlation))
+    }
+    p <- p + ggraph::geom_node_point(size = 5) +
       ggraph::geom_node_label(ggplot2::aes(label = name),
                               size = 5) +
       ggraph::theme_graph()

--- a/R/network_graph.R
+++ b/R/network_graph.R
@@ -45,7 +45,7 @@ apply_colors <- function(R, name = "RdBu") {
     }
   }
   dat <- data.frame(color = color_vector,
-                    label = r_vector)
+                    label = round(r_vector, 3))
   return(dat)
 }
 
@@ -114,13 +114,19 @@ plot_posterior_correlation <- function(output_model, labels = NULL,
                                                mode = "undirected",
                                                diag = FALSE)
 
-  igraph::E(graph)$Correlation <- apply_colors(R, palette)$color
+  df <- apply_colors(R)
+
+  igraph::E(graph)$Correlation <- df$color #apply_colors(R, palette)
+  igraph::E(graph)$label <- df$label
   igraph::E(graph)$P_value <- weight_vector
 
   if (style == "arc") {
     p <- ggraph::ggraph(graph, layout = "linear", circular = TRUE) +
       ggraph::geom_edge_arc(ggplot2::aes(edge_width = P_value,
-                                         edge_color = Correlation)) +
+                                         edge_color = Correlation,
+                                         label = label),
+                            angle_calc = "along",
+                            check_overlap = TRUE) +
       ggraph::geom_node_point(size = 5) +
       ggraph::geom_node_label(ggplot2::aes(label = name),
                               size = 5) +
@@ -128,7 +134,10 @@ plot_posterior_correlation <- function(output_model, labels = NULL,
   } else if (style == "line") {
     p <- ggraph::ggraph(graph, layout = "linear", circular = TRUE) +
       ggraph::geom_edge_link(ggplot2::aes(edge_width = P_value,
-                                          edge_color = Correlation)) +
+                                          edge_color = Correlation,
+                                          label = label),
+                             angle_calc = "along",
+                             check_overlap = TRUE) +
       ggraph::geom_node_point(size = 5) +
       ggraph::geom_node_label(ggplot2::aes(label = name),
                               size = 5) +

--- a/man/apply_colors.Rd
+++ b/man/apply_colors.Rd
@@ -14,7 +14,7 @@ palette with at least 9 distinct colors. All diverging ColorBrewer palettes
 meet this requirement. Default: "RdBu"}
 }
 \value{
-A data frame with columns \code{color} and \code{label}. \code{label} is the
+A data frame with columns `color` and `label`. `label` is the
 correlation coefficient.
 }
 \description{

--- a/man/assemble_statistics.Rd
+++ b/man/assemble_statistics.Rd
@@ -18,7 +18,7 @@ in the brmsfit object
 This function encapsulates all of the computations associated with
 assessing phenotypic integration using a brmsfit object from a
 multiresponse model. For example, the wild sunflower results distributed
-with this package (in \code{mod_wild}) were produced from individual-level data
+with this package (in `mod_wild`) were produced from individual-level data
 with the following set of commands:
 
 \preformatted{
@@ -35,9 +35,9 @@ mod_wild <- brm(wild_CN + wild_SLA + wild_branch + wild_stem +
                 family = "gaussian")
 }
 
-Once you've loaded this library, \code{mod_wild} is available for use. See the
-example below. In addition, if you are familiar with \code{brms}, you can use
-any of the usual \code{brms} methods to learn more about \code{mod_wild}.
+Once you've loaded this library, `mod_wild` is available for use. See the
+example below. In addition, if you are familiar with `brms`, you can use
+any of the usual `brms` methods to learn more about `mod_wild`.
 }
 \examples{
 assemble_statistics(mod_wild)

--- a/man/plot_posterior_correlation.Rd
+++ b/man/plot_posterior_correlation.Rd
@@ -3,35 +3,43 @@
 \name{plot_posterior_correlation}
 \alias{plot_posterior_correlation}
 \title{Visualize a the posterior distribution of a correlation matrix from
-the output of \code{brm()}}
+the output of `brm()`}
 \usage{
 plot_posterior_correlation(
   output_model,
   labels = NULL,
   style = "arc",
-  palette = "RdBu"
+  palette = "RdBu",
+  label_edges = FALSE,
+  digits = 2
 )
 }
 \arguments{
-\item{output_model}{An object of class \code{brmsfit}}
+\item{output_model}{An object of class `brmsfit`}
 
-\item{labels}{Labels for the nodes. If \code{NULL} then the names used in the
-\code{brms} model are also used here}
+\item{labels}{Labels for the nodes. If `NULL` then the names used in the
+`brms` model are also used here}
 
 \item{style}{Style of visualization, "arc" (default) or "line"}
 
-\item{palette}{RColorBrewer palette to use. See \code{apply_colors()} for
+\item{palette}{RColorBrewer palette to use. See `apply_colors()` for
 details. Default: "RdBu"}
+
+\item{label_edges}{Label edges of graph with posterior mean correlation.
+Default: FALSE}
+
+\item{digits}{Number of digits to use in rounding posterior mean correlation
+(only relevant if label_edges == TRUE). Default: 2}
 }
 \value{
 A list with two elements
 
-\code{p} A gggraph object that can be further modified
+`p` A gggraph object that can be further modified
 
-\code{R} The posterior mean correlation matrixtmp
+`R` The posterior mean correlation matrixtmp
 }
 \description{
-This function plots the posterior correlation matrix from a \code{brm()} analysis
+This function plots the posterior correlation matrix from a `brm()` analysis
 as a series of arcs with the color of each connection representing the
 posterior mean of the correlation coefficient and the width representing
 the one-sided probability that the coefficient is different from 0.

--- a/man/report_trait_names.Rd
+++ b/man/report_trait_names.Rd
@@ -7,13 +7,13 @@
 report_trait_names(output_model)
 }
 \arguments{
-\item{output_model}{An object of class \code{brmsfit}}
+\item{output_model}{An object of class `brmsfit`}
 }
 \value{
 A vector of parameter names
 }
 \description{
 This is a utility function to make it easy to find the traits used in a
-\code{brms} analysis and to report them in the order they will appear when
+`brms` analysis and to report them in the order they will appear when
 the posterior correlation matrix is plotted
 }


### PR DESCRIPTION
Posterior mean correlation coefficients are **_not_** displayed by default. Select `label_edges = TRUE` in the call to `plot_posterior_correlation()` to show them. Use the `digits` argument to control the number of decimal places displayed (default = 2).